### PR TITLE
Promote 1.3.2 to 2.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 tbotRulerGroup = com.rposcro.tbot
-tbotRulerVersion = 1.3.2
+tbotRulerVersion = 2.0.0


### PR DESCRIPTION
Promote to 2.0.0 due to significant refactorings and changes introduced in 1.3.2